### PR TITLE
♻️ `FileCreator` works within passed container

### DIFF
--- a/driver/libs/containers/_base_containers.py
+++ b/driver/libs/containers/_base_containers.py
@@ -72,13 +72,9 @@ class _BaseContainer(ABC):
         pass
 
     def __enter__(self) -> "_BaseContainer":
-        # Read-only volume with users' scripts
-        scripts_volume = f'{LOCAL_USER_SCRIPTS_DIR}:/{DOCKER_USER_SCRIPTS_DIR}:ro'
-
         # Creating and starting the container
         self._container: Container = client.containers.create(
             image=self._docker_image,
-            volumes=[scripts_volume],
             mem_limit=self.__memory_limit,
             tty=True,
         )
@@ -86,7 +82,9 @@ class _BaseContainer(ABC):
         # Starting the container
         self._container.start()
         # Creating directory for compiled files and file for stdout of `time` command
-        self._container.exec_run(f'sh -c \'mkdir {DOCKER_COMPILED_FILES_DIR} && touch {DOCKER_TIME_OUTPUT_FILE}\'')
+        self._container.exec_run(
+            f'sh -c \'mkdir {DOCKER_COMPILED_FILES_DIR} {DOCKER_USER_SCRIPTS_DIR} && touch {DOCKER_TIME_OUTPUT_FILE}\''
+        )
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/driver/libs/files/__init__.py
+++ b/driver/libs/files/__init__.py
@@ -2,16 +2,19 @@ import typing as t
 import os
 import uuid
 
+from driver.libs.containers import _BaseContainer
 from driver.libs.enums import ProgrammingLanguage
 from driver.libs.types import Filename
-from config import LOCAL_USER_SCRIPTS_DIR
+from config import LOCAL_USER_SCRIPTS_DIR, DOCKER_USER_SCRIPTS_DIR
 
 ProgrammingLanguagesMember = t.TypeVar('ProgrammingLanguagesMember', bound=ProgrammingLanguage)
 
 
 class FileCreator:
-    def __init__(self, source_code: str, programming_language: ProgrammingLanguage):
-        self.__source_code = source_code
+    def __init__(self, source_code: str, programming_language: ProgrammingLanguage, container: _BaseContainer):
+        self.filename: str
+        self.__container = container._container
+        self.__source_code = self.__escape_quotes(source_code)
         self.__programming_language = programming_language
 
     def __generate_filename(self) -> Filename:
@@ -19,16 +22,24 @@ class FileCreator:
         extension = self.__programming_language.value.file_extension
         return f'{name}.{extension}'
 
-    def __enter__(self):
+    def __enter__(self) -> "FileCreator":
         # Generating unique name of the file
         self.filename = self.__generate_filename()
-        # Building path to file
-        self.__file_path = LOCAL_USER_SCRIPTS_DIR / self.filename
 
         # Writing passed source code to the file
-        with open(self.__file_path, 'w') as file:
-            file.write(self.__source_code)
+        file_write_command = f'sh -c \'echo -e \"{self.__source_code}\" > {DOCKER_USER_SCRIPTS_DIR}/{self.filename}\''
+        self.__container.exec_run(cmd=file_write_command)
         return self
 
+    @staticmethod
+    def __escape_quotes(data: str) -> str:
+        replacement_map = {
+            '\'': r'\'',
+            '\"': r'\"',
+        }
+        for replace_from, replace_to in replacement_map.items():
+            data = data.replace(replace_from, replace_to)
+        return data
+
     def __exit__(self, exc_type, exc_val, exc_tb):
-        os.remove(self.__file_path)
+        self.__container.exec_run(cmd=f'rm {DOCKER_USER_SCRIPTS_DIR}/{self.filename}')

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ Container = ContainersFactory.get(language)
 source = """print(1)\nprint(2)\nprint(3)"""
 
 with Container(time_limit=2, memory_limit='128m') as container:
-    with FileCreator(source_code=source, programming_language=language) as file_creator:
+    with FileCreator(source_code=source, programming_language=language, container=container) as file_creator:
         for _ in range(10):
             execution_options = CodeExecutionCommandOptions(filename=file_creator.filename, stdin=r'')
             result = container.execute(options=execution_options)

--- a/tests/test_libs/test_containers_execution.py
+++ b/tests/test_libs/test_containers_execution.py
@@ -40,7 +40,7 @@ class BaseTestContainer(ABC):
         pass
 
     def run_source_code(self, source_code: str, container: _BaseContainer) -> ProcessedContainerExecutionResult:
-        with FileCreator(source_code, self._programming_language) as file_creator:
+        with FileCreator(source_code, self._programming_language, container) as file_creator:
             execution_options = CodeExecutionCommandOptions(filename=file_creator.filename, stdin='')
             return container.execute(execution_options)
 

--- a/tests/test_libs/test_files.py
+++ b/tests/test_libs/test_files.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from config import LOCAL_USER_SCRIPTS_DIR
+from driver.libs.containers import PythonContainer
 from driver.libs.files import FileCreator
 from driver.libs.files.utils import get_compiled_filename
 from driver.libs.enums import ProgrammingLanguage
@@ -11,21 +12,22 @@ from driver.libs.enums import ProgrammingLanguage
 def test_file_creator_context_menu():
     source_code = 'print(1)'
 
-    with FileCreator(source_code, ProgrammingLanguage.PYTHON) as file_creator:
-        path_to_file = LOCAL_USER_SCRIPTS_DIR / file_creator.filename
-        
-        # File should exist
-        assert os.path.exists(path_to_file)
-        # File should have correct extension
-        assert 'py' in file_creator.filename
+    with PythonContainer(time_limit=1, memory_limit='64m') as container:
+        with FileCreator(source_code, ProgrammingLanguage.PYTHON, container) as file_creator:
+            path_to_file = LOCAL_USER_SCRIPTS_DIR / file_creator.filename
 
-        with open(path_to_file) as created_file:
-            file_content = created_file.read()
-            # File should have correct content
-            assert file_content == source_code
+            # File should exist
+            assert os.path.exists(path_to_file)
+            # File should have correct extension
+            assert 'py' in file_creator.filename
 
-    # After exiting FileCreator context menu file should be deleted
-    assert not os.path.exists(path_to_file)
+            with open(path_to_file) as created_file:
+                file_content = created_file.read()
+                # File should have correct content
+                assert file_content == source_code
+
+        # After exiting FileCreator context menu file should be deleted
+        assert not os.path.exists(path_to_file)
 
 
 def test_get_compiled_filename():


### PR DESCRIPTION
Since now, `FileCreator` initialization requires container (`_BaseContaier` type) in order to create files directly inside the container.
Deleted mounting of volume, tests are adjusted to new behaviour of `FileCreator`